### PR TITLE
PHPcs install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 	"minimum-stability": "stable",
 	"config": {
 		"allow-plugins": {
-			"automattic/jetpack-composer-plugin": true
+			"automattic/jetpack-composer-plugin": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"autoload": {
@@ -30,7 +31,9 @@
 		"wp-plugin-slug": "plugin-init"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "9"
+		"phpunit/phpunit": "9",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"scripts": {
 		"test:phpunit": "./vendor/bin/phpunit phpunit"


### PR DESCRIPTION
En vez de bajar phpcs por medio de la librería de Woo, se pude baar directamente phpcs: 

composer require --dev dealerdirect/phpcodesniffer-composer-installer

Tambien hay que instalar las reglas de wordpress que estan especificadas en el phpcs.xml con:

composer require wp-coding-standards/wpcs

Luego ejecutar el comando:

php ./vendor/bin/phpcs --warning-severity=0 --ignore-annotations --extensions=php --report=csv --report-file=./phpcs_error.csv ./lib

Así ejecutamos phpcs a través de php con el xml que ya tenemos.

Para verificar las reglas que tiene instalada el phpcs ejecutar:

./vendor/bin/phpcs -i